### PR TITLE
Hide Aligner

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,7 +46,7 @@ More information and guidances can be found in the:
   how-to-guides/pci-ssn-pii-detection
   how-to-guides/pci-ssn-pii-redaction
   how-to-guides/custom-vocabulary
-  how-to-guides/aligner
+  ..how-to-guides/aligner
   how-to-guides/s3-callbacks
   how-to-guides/number-formatting
   how-to-guides/voicemail


### PR DESCRIPTION
Aligner is not ready for prime-time in v3 yet, so removing it from the
index.