### PR TITLE
Add line break to ensure RTD renders code blocks properly

### DIFF
--- a/docs/how-to-guides/hello-world.rst
+++ b/docs/how-to-guides/hello-world.rst
@@ -44,6 +44,7 @@ Step **(2)**: Upload a media file for transcription and analysis
 To upload a recording for transcription and analysis, POST to /media with the recording as an attachment named media (you can also provide a URL to your recording instead using the form field 'mediaUrl').
 
 Using local media:
+
 .. code-block:: sh
   :linenos:
   :emphasize-lines: 2
@@ -55,6 +56,7 @@ Using local media:
     | jq .
 
 Using a remote media URL:
+
 .. code-block:: sh
   :linenos:
   :emphasize-lines: 2


### PR DESCRIPTION
RTFD does not like code blocks and text separated by only one carriage return. Added a second on the examples that were not rendering properly