### PR TITLE
Aligner & Reprocessing & some minor fixes.

### DIFF
--- a/docs/how-to-guides/reprocessing.md
+++ b/docs/how-to-guides/reprocessing.md
@@ -1,0 +1,41 @@
+# Reprocessing your files
+
+VoiceBase allows you to re-run the post-processing with different options.
+
+A common use-case for this is to update the media file with a human edited transcript, and re-run knowledge extraction with the new transcript. This is documented in the [aligner](aligner.md) section.
+
+You may also use the reprocessing feature to re-process different configuration options without requesting a new transcript.
+
+For example, you may use the reprocessing feature to:
+* Enable Knowledge Extraction, if you previously did not have this set
+* Submit a human edited plaintext transcript, and receive a closed-captioning file.
+* Enable PCI Detection / Redaction if you decide you would like to remove PCI from your transcripts and / or audio files.
+* Enable Number formatting, if you previously set this to disabled.
+* Run new machine learning models on existing media files.
+
+*Please Note:* Custom Vocabulary modifies the speech engine with a custom set of terms for audio processing. Since the speech engine is not run during reprocessing, Custom Vocabulary is not updated.
+
+## Examples
+
+Assume that MEDIA_ID='7eb7964b-d324-49cb-b5b5-76a29ea739e1' is a valid media ID of a previously uploaded file for transcription.
+
+
+Make a POST request to `/media/${MEDIA_ID}` including a `configuration` and a `transcript` attachment. Do *not* include a 'media' attachment or 'mediaUrl'
+
+
+```bash
+curl -v -s https://apis.voicebase.com/v3/media/$MEDIA_ID \
+  --header "Authorization: Bearer ${TOKEN}" \
+  -X POST \
+  --form configuration='{}' \
+  --form transcript=@transcript.text
+```
+
+Then, make a GET request on the `/media/${MEDIA_ID}` resource to download the latest transcripts and configured analytics and predictions.
+
+```bash
+curl -v -s https://apis.voicebase.com/v3/media/$MEDIA_ID \
+  --header "Authorization: Bearer ${TOKEN}"
+```
+
+Note that the simple act of including a transcript with the POST triggers reprocessing of the configuration file.

--- a/docs/how-to-guides/swagger-codegen.md
+++ b/docs/how-to-guides/swagger-codegen.md
@@ -4,9 +4,9 @@ VoiceBase V3 API follows the OpenAPI 2.0 Specification  (also known as Swagger R
 
 By following the specification, the API is documented in a way that code generation tools can understand, saving you time and effort on generating code to build requests or access the response from the API.
 
-The Voicebase V3 OpenAPI specification resides at https://apis.voicebase.com/v3/defs/v3-api.yaml
+The VoiceBase V3 OpenAPI specification resides at https://apis.voicebase.com/v3/defs/v3-api.yaml
 
-This document is a summary of how to use the Swagger Code Generation tool to generate a Voicebase V3 client.
+This document is a summary of how to use the Swagger Code Generation tool to generate a VoiceBase V3 client.
 We assume that you already have installed Java 8 and Maven.
 
 ## Download Swagger Codegen CLI tool

--- a/docs/how-to-guides/transcripts.md
+++ b/docs/how-to-guides/transcripts.md
@@ -19,7 +19,7 @@ Speaker identification is enabled by multi-channel audio, where each channel is 
 
 ###### How to read it
 * "p" = Position (word # in the transcript)
-* "c" = Confidence (A value between 0-1 that relates to the confidence percent ex: 0.88 = 88%.  When the metadata flag is present confidence contains an arbireary value.)
+* "c" = Confidence (A value between 0-1 that relates to the confidence percent ex: 0.88 = 88%.  When the metadata flag is present confidence contains an arbitrary value.)
 * "s" = Start time (milliseconds)
 * "e" = End time (milliseconds)
 * "w" = The word itself (When the metadata flag is present "w" refers to the speaker)

--- a/docs/how-to-guides/voicemail.md
+++ b/docs/how-to-guides/voicemail.md
@@ -16,14 +16,11 @@ Below is an optimized configuration for fast and accurate voicemail transcriptio
 {  
    "speechModel" : {
          "language" : "en-US",
-          "extensions" : [ "voicemail" ] 
-   }
+          "extensions" : [ "voicemail" ]
+   },
    "knowledge": {
      "enableDiscovery" : false
-   },
-  "transcript": {  
-    "enableNumberFomatting" : true
-  },       
+   },       
   "publish":{  
      "callbacks": [  
         {  

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,10 @@ More information and guidances can be found in the:
   how-to-guides/number-formatting
   how-to-guides/voicemail
   how-to-guides/metadata
+  how-to-guides/reprocessing
+  how-to-guides/aligner
   how-to-guides/swagger-codegen
+
 
 
 .. _api-reference:


### PR DESCRIPTION
Enabled Aligner feature in Index.md
Added “reprocessing” write-up (different than Aligner) for advanced
reprocessing features that don’t really fall under ‘transcript
alignment’.
Removed ‘enableNumberFormatiing’ from sample config in voicemail.md,
since it now enabled by default.
Capitalization fixed for ‘VoiceBase’ in swagger-codegen.md