### PR TITLE
Keeping up with the API - Added Date Created field to all Media Responses

### DIFF
--- a/docs/how-to-guides/aligner.md
+++ b/docs/how-to-guides/aligner.md
@@ -41,6 +41,7 @@ The response contains the mediaId you will use when aligning (e.g., 7eb7964b-d32
     "mediaId": "7eb7964b-d324-49cb-b5b5-76a29ea739e1",
     "status": "accepted",
     "dateCreated": "2017-06-22T18:23:02Z",
+    "dateFinished": "2017-06-22T18:23:58Z",
     "mediaContentType": "audio/mp3",
     "length": 10031,
     "metadata": {}

--- a/docs/how-to-guides/hello-world.rst
+++ b/docs/how-to-guides/hello-world.rst
@@ -89,6 +89,7 @@ The response includes a *mediaId* (assigned by the API) and a status of *accepte
     "mediaId": "10827f19-7574-4b54-bf9d-9387999eb5ec",
     "status": "accepted",
     "dateCreated": "2017-06-22T18:23:02Z",
+    "dateFinished": "2017-06-22T18:23:58Z",
     "mediaContentType": "audio/mp3",
     "length": 10031,
     "metadata": {}

--- a/docs/how-to-guides/transcripts.md
+++ b/docs/how-to-guides/transcripts.md
@@ -30,6 +30,7 @@ Speaker identification is enabled by multi-channel audio, where each channel is 
   "mediaId": "bc14632d-e81b-4673-992d-5c5fb6573fb8",
   "status": "finished",
   "dateCreated": "2017-06-22T19:18:49Z",
+  "dateFinished": "2017-06-22T19:19:27Z",
   "mediaContentType": "audio/x-wav",
   "length": 10031,
   "transcript": {


### PR DESCRIPTION
dateFinished is not in the high level of media response, but all
examples which have dateCreated have been updated to also include
dateFinished with a reasonable response time.