### PR TITLE
Fix/customVocab predefined List

### DIFF
--- a/docs/how-to-guides/custom-vocabulary.md
+++ b/docs/how-to-guides/custom-vocabulary.md
@@ -125,10 +125,11 @@ If you have a recording to transcribe and want to add ad hoc custom terms specif
 
 ### Pre-Defined List
 
-You can add a re-usable custom vocabulary list to your VoiceBase account with a PUT request to /v3/definition/vocabularies/($VOCAB-LIST-NAME) with Content-Type application/json. In this example, we will create a list called 'earningsCalls' by making a PUT req and the following body:
+You can add a re-usable custom vocabulary list to your VoiceBase account with a PUT request to /v3/definition/vocabularies/($VOCAB-LIST-NAME) with Content-Type application/json and the following body:
 
 ```json
 {
+  "vocabularyName": "earningsCalls",
   "terms": [
     {
       "soundsLike": [
@@ -183,7 +184,7 @@ curl https://apis.voicebase.com/v3/definition/vocabularies/earningsCalls \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer ${TOKEN}" \
   --data '{
-      "name": "earningsCalls",
+      "vocabularyName": "earningsCalls",
       "terms": [
         {
           "soundsLike": [
@@ -217,7 +218,7 @@ curl https://apis.voicebase.com/v3/definition/vocabularies/earningsCalls \
       "href": "/v3/definition/vocabularies/earningsCalls"
     }
   },
-  "name": "earningsCalls",
+  "vocabularyName": "earningsCalls",
   "terms": [
     {
       "term": "AFFO",

--- a/docs/how-to-guides/custom-vocabulary.md
+++ b/docs/how-to-guides/custom-vocabulary.md
@@ -125,11 +125,10 @@ If you have a recording to transcribe and want to add ad hoc custom terms specif
 
 ### Pre-Defined List
 
-You can add a re-usable custom vocabulary list to your VoiceBase account with a PUT request to /v3/definition/vocabularies/($VOCABLISTNAME) with Content-Type application/json and the following body:
+You can add a re-usable custom vocabulary list to your VoiceBase account with a PUT request to /v3/definition/vocabularies/($VOCAB-LIST-NAME) with Content-Type application/json. In this example, we will create a list called 'earningsCalls' by making a PUT req and the following body:
 
 ```json
 {
-  "name": "earningsCalls",
   "terms": [
     {
       "soundsLike": [


### PR DESCRIPTION
Removed ‘name’ from the definition JSON as per: Removed ‘name’ from the definition JSON as per: https://voicebase.jira.com/browse/V2-5312
Validated on V3 console and saved example into v3 console docs.